### PR TITLE
Require postcss to prevent errors on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "build": "npm run css:build"
   },
   "dependencies": {
+    "autoprefixer": "^10.4.13",
     "bootstrap": "^4.4.1",
     "breakpoint-sass": "^2.7.1",
-    "autoprefixer": "^10.4.13",
     "node-sass": "^7.0.3",
     "node-sass-magic-importer": "^5.3.2",
     "nodemon": "^2.0.20",
+    "postcss": "^8.4.19",
     "postcss-cli": "^10.0.0"
   }
 }


### PR DESCRIPTION
running `npm run build` ran into errors

```
Please install PostCSS 8 or above
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! y-lb@1.0.0 css:prefix: `postcss --use autoprefixer -b '> 10%' ./css/*.css -r`
npm ERR! Exit status 1
```

this resolves that.
