### PR TITLE
fix: Dependency error while installing a site

### DIFF
--- a/y_lb.info.yml
+++ b/y_lb.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - drupal:layout_builder_blocks
   - drupal:layout_builder_restrictions
   - drupal:lb_claro
+  - drupal:scheduler


### PR DESCRIPTION
# How to review

- [ ] Apply this code and run `APP_ENV=dev ./vendor/bin/drush -y si openy openy_configure_profile.preset=extended openy_theme_select.theme=openy_carnation openy_terms_of_use.agree_openy_terms=1 install_configure_form.enable_update_status_emails=NULL --account-name=admin --account-pass=admin --uri="https://localhost:8080" --site-name="YUSAOpenY"` you should not see errors like this:

```bash
Configuration objects provided by <em class="placeholder">y_lb</em> have unmet depend  
  encies: <em class="placeholder">core.entity_form_display.node.landing_page_lb.default  
   (scheduler)</em>                                                                      
                     
```

<img width="878" alt="Screenshot 2023-03-02 at 15 26 24" src="https://user-images.githubusercontent.com/26228931/222441350-be748821-12e4-494c-9c45-5a5cd458af80.png">
