### PR TITLE
#52: Support non-bootstrap layout builder layouts

### DIFF
--- a/y_lb.module
+++ b/y_lb.module
@@ -127,9 +127,14 @@ function y_lb_preprocess_block(&$variables) {
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function y_lb_theme_suggestions_layout_alter( array &$suggestions, array $variables ) {
-  $entity = $variables['content']['#entity'] ?? NULL;
+  $original_hook = $variables['theme_hook_original'];
+  if ($original_hook !== 'blb_section' && !str_starts_with($original_hook, 'blb_section__')) {
+    return;
+  }
+  // Remove existing suggestions.
   $suggestions = [];
   $suggestions[] = 'blb_section__y_lb';
+  $entity = $variables['content']['#entity'] ?? NULL;
   if ($entity && $entity instanceof EntityInterface) {
     $suggestions[] = 'blb_section__' . $entity->bundle();
     $label = $variables['content']['#settings']['label'] ?? NULL;


### PR DESCRIPTION
I'm assuming here that the `blb_section*` suggestions are only for the `blb_section` theme hook.  

Fixes #52

This includes and supersedes #50 (I just wanted to avoid giving you two PRs that I'm fairly sure would conflict).

Thanks!