### PR TITLE
fix: enable node revision delete during update

### DIFF
--- a/y_lb.install
+++ b/y_lb.install
@@ -42,6 +42,7 @@ function y_lb_update_9002(&$sandbox) {
  * Add node_revision_delete configuration.
  */
 function y_lb_update_9003(&$sandbox) {
+  \Drupal::service('module_installer')->install(['node_revision_delete']);
   $path = \Drupal::service('extension.list.module')->getPath('y_lb') . '/config/install';
   /** @var \Drupal\config_import\ConfigImporterService $config_importer */
   $config_importer = \Drupal::service('config_import.importer');


### PR DESCRIPTION
This enables it in the update but doesn't try to address sites that have already run y_lb_update_9003().

Addresses #59