### PR TITLE
DS-851 Add main-content anchor on layout builder pages

### DIFF
--- a/templates/ws-header.html.twig
+++ b/templates/ws-header.html.twig
@@ -66,4 +66,5 @@
       </div>
     </div>
   </header>
+  <a id="main-content" tabindex="-1" class="sr-only sr-only-focusable"></a>
 {% endif %}


### PR DESCRIPTION
**Problem:** 

Our theme has a "Skip to main content" link at the top of the page, but so far Layout Builder pages have broken that functionality and the link has been nonfunctional. The `#main-content` anchor should be at the beginning of the main content of the page, specifically _after_ long lists of navigation links.

**Resolution:**

Since our navigation is build inside of Layout Builder we can't use standard methods (Drupal regions, page.tpl.php) to place the anchor. 

Placing it at the end of `ws-header.html.twig` will: 
- ensure it is after the nav
- let us only add it one place (instead of in every content type's template)

This method could break if the user removes the `ws-header` section from the page. In that case, it's possible the main content is at the top of the page, in which case there'd be nothing to skip, or the page could be being used in a non-interactive display, in which case the anchor would be unnecessary.

Are there other cases in which this would _not_ work? 

**Alternative solution:**

The only thing I can invision is doing some work in php to list the layout builder sections and insert the anchor in the first one that's not `ws-header` but that seems... overly complicated and I'm not sure how to go about doing it.