### PR TITLE
fix: Correct mislabeled twitter/linkedin share links

### DIFF
--- a/src/Plugin/Block/NodeShareBlock.php
+++ b/src/Plugin/Block/NodeShareBlock.php
@@ -86,8 +86,8 @@ class NodeShareBlock extends BlockBase implements ContainerFactoryPluginInterfac
     $url = urlencode($this->node->toUrl('canonical', ['absolute' => TRUE])->toString());
     $links = [
       'facebook' => 'https://www.facebook.com/sharer.php?u=' . $url,
-      'twitter'  => 'https://www.linkedin.com/shareArticle?mini=true&url=' . $url,
-      'linkedin' => 'https://twitter.com/intent/tweet?url=' . $url,
+      'twitter' => 'https://twitter.com/intent/tweet?url=' . $url,
+      'linkedin'  => 'https://www.linkedin.com/shareArticle?mini=true&url=' . $url,
     ];
 
     $this->moduleHandler->alter('lb_node_share_block_links', $links);


### PR DESCRIPTION
As reported on Slack

![image](https://github.com/YCloudYUSA/y_lb/assets/238201/eca90243-7648-4b4e-8dc0-fe44e25a9e50)
