### PR TITLE
feat(DS-848): Add metatag helper fields and configure meta defaults

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "drupal/lb_webform" : "^1.0 || ^1.1",
         "drupal/menu_item_extras" : "^2.0 || ^3.0",
         "drupal/node_revision_delete" : "^2.0@alpha || ^2",
+        "drupal/openy_gtranslate" : "^1.0",
         "drupal/scheduler": "^2.0@RC || ^2.0",
         "drupal/ws_lb_tabs" : "^1.0",
         "drupal/ws_code_block" : "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drupal/lb_testimonial_blocks" : "^1.0",
         "drupal/lb_webform" : "^1.0 || ^1.1",
         "drupal/menu_item_extras" : "^2.0 || ^3.0",
+        "drupal/metatag": "*",
         "drupal/node_revision_delete" : "^2.0@alpha || ^2",
         "drupal/openy_gtranslate" : "^1.0",
         "drupal/scheduler": "^2.0@RC || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "drupal/y_facility" : "^1.0",
         "drupal/y_lb_article" : "^1.0 || ^1.1",
         "drupal/pathauto" : "^1.11",
+        "open-y-subprojects/openy_focal_point" : "^1.1",
         "php": ">=8.1"
     },
     "license": "GPL-2.0+",

--- a/config/install/core.entity_form_display.node.landing_page_lb.default.yml
+++ b/config/install/core.entity_form_display.node.landing_page_lb.default.yml
@@ -2,11 +2,37 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.images_library
+    - field.field.node.landing_page_lb.field_meta_description
+    - field.field.node.landing_page_lb.field_meta_image
+    - field.field.node.landing_page_lb.field_meta_tags
     - field.field.node.landing_page_lb.layout_builder__layout
     - node.type.landing_page_lb
   module:
+    - field_group
+    - metatag
+    - openy_focal_point
     - path
     - scheduler
+third_party_settings:
+  field_group:
+    group_metadata:
+      children:
+        - field_meta_description
+        - field_meta_image
+        - field_meta_tags
+      label: Metadata
+      region: content
+      parent_name: ''
+      weight: 1
+      format_type: details
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        open: true
+        description: "This content is used to provide context to search engines and page previews. For the best user experience <a href=\"https://backlinko.com/on-page-seo#optimize-title-and-description-tags\">create clickable titles</a>, <a href=\"https://moz.com/learn/seo/meta-description\">write a compelling description</a>, and <a href=\"https://yoast.com/image-seo/#always\">add a descriptive image</a>.\r\n<br/><br/>\r\nThe collapsed <em>Meta tags</em> section should only be edited by advanced users."
+        required_fields: true
 id: node.landing_page_lb.default
 targetEntityType: node
 bundle: landing_page_lb
@@ -14,26 +40,57 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_meta_description:
+    type: string_textarea
+    weight: 12
+    region: content
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_meta_image:
+    type: openy_focal_point_entity_browser_entity_reference
+    weight: 13
+    region: content
+    settings:
+      entity_browser: images_library
+      field_widget_display: rendered_entity
+      field_widget_display_settings:
+        view_mode: thumbnail_for_preview
+      field_widget_edit: '1'
+      field_widget_remove: '1'
+      open: '1'
+      selection_mode: selection_append
+      field_widget_replace: 0
+    third_party_settings: {  }
+  field_meta_tags:
+    type: metatag_firehose
+    weight: 14
+    region: content
+    settings:
+      sidebar: false
+      use_details: true
+    third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 1
+    weight: 2
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 4
+    weight: 5
     region: content
     settings:
       display_label: true
@@ -46,11 +103,16 @@ content:
     third_party_settings: {  }
   redirect:
     type: string_textfield
-    weight: 6
+    weight: 7
     region: content
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
@@ -61,7 +123,7 @@ content:
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 5
+    weight: 6
     region: content
     settings:
       display_label: true
@@ -76,7 +138,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 3
     region: content
     settings:
       match_operator: CONTAINS
@@ -98,3 +160,5 @@ content:
 hidden:
   addthis: true
   layout_builder__layout: true
+  publish_on: true
+  unpublish_on: true

--- a/config/install/core.entity_view_display.node.landing_page_lb.default.yml
+++ b/config/install/core.entity_view_display.node.landing_page_lb.default.yml
@@ -2,10 +2,16 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.landing_page_lb.field_meta_description
+    - field.field.node.landing_page_lb.field_meta_image
+    - field.field.node.landing_page_lb.field_meta_tags
     - field.field.node.landing_page_lb.layout_builder__layout
     - node.type.landing_page_lb
     - system.menu.account
     - system.menu.footer
+    - system.menu.footer-menu-center
+    - system.menu.footer-menu-left
+    - system.menu.footer-menu-right
     - system.menu.main
   content:
     - 'block_content:basic_block:cb76bc7c-a957-4b69-96fb-e565ee85f38a'
@@ -15,6 +21,8 @@ dependencies:
     - bootstrap_layout_builder
     - layout_builder
     - layout_builder_restrictions
+    - metatag
+    - openy_gtranslate
     - system
     - user
     - y_lb
@@ -644,8 +652,6 @@ third_party_settings:
                   background_size: cover
               text_color:
                 class: null
-              text_alignment:
-                class: null
               padding:
                 class: _none
               padding_left:
@@ -709,6 +715,8 @@ third_party_settings:
                   class: _none
               scroll_effects:
                 class: null
+              text_alignment:
+                class: null
           container_wrapper_bg_color_class: ''
           container_wrapper_bg_media: null
           container: w-100
@@ -727,7 +735,6 @@ third_party_settings:
         layout_id: 'bootstrap_layout_builder:blb_col_1'
         layout_settings:
           label: Body
-          context_mapping: {  }
           container_wrapper_classes: ''
           container_wrapper_attributes: null
           container_wrapper:
@@ -748,8 +755,6 @@ third_party_settings:
                   background_size: cover
               text_color:
                 class: null
-              text_alignment:
-                class: null
               padding:
                 class: _none
               padding_left:
@@ -813,6 +818,8 @@ third_party_settings:
                   class: _none
               scroll_effects:
                 class: null
+              text_alignment:
+                class: null
           container_wrapper_bg_color_class: ''
           container_wrapper_bg_media: null
           container: container
@@ -825,6 +832,7 @@ third_party_settings:
           breakpoints: {  }
           layout_regions_classes: {  }
           remove_gutters: '0'
+          context_mapping: {  }
         components: {  }
         third_party_settings: {  }
       -
@@ -840,7 +848,7 @@ third_party_settings:
             configuration:
               id: 'block_content:cb76bc7c-a957-4b69-96fb-e565ee85f38a'
               label: 'Footer Copyright Block'
-              label_display: 0
+              label_display: '0'
               provider: block_content
               status: true
               info: ''
@@ -1036,7 +1044,7 @@ third_party_settings:
             configuration:
               id: 'system_menu_block:footer-menu-left'
               label: Left
-              label_display: 1
+              label_display: '1'
               provider: system
               context_mapping: {  }
             weight: 0
@@ -1132,7 +1140,7 @@ third_party_settings:
             configuration:
               id: 'system_menu_block:footer-menu-center'
               label: Center
-              label_display: 1
+              label_display: '1'
               provider: system
               context_mapping: {  }
               level: 1
@@ -1231,7 +1239,7 @@ third_party_settings:
             configuration:
               id: 'system_menu_block:footer-menu-right'
               label: Right
-              label_display: 1
+              label_display: '1'
               provider: system
               context_mapping: {  }
               level: 1
@@ -1429,7 +1437,7 @@ third_party_settings:
             configuration:
               id: 'system_menu_block:footer'
               label: Footer
-              label_display: 0
+              label_display: '0'
               provider: system
               context_mapping: {  }
               level: 1
@@ -1560,6 +1568,10 @@ mode: default
 content: {  }
 hidden:
   addthis: true
+  field_meta_description: true
+  field_meta_image: true
+  field_meta_tags: true
   langcode: true
   layout_builder__layout: true
   links: true
+  search_api_excerpt: true

--- a/config/install/field.field.node.landing_page_lb.field_meta_description.yml
+++ b/config/install/field.field.node.landing_page_lb.field_meta_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_description
+    - node.type.landing_page_lb
+id: node.landing_page_lb.field_meta_description
+field_name: field_meta_description
+entity_type: node
+bundle: landing_page_lb
+label: 'Meta description'
+description: "A brief and concise summary of the page's content that is a maximum of 160 characters in length. The description may be used by search engines to display a snippet about the page in search results."
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.field.node.landing_page_lb.field_meta_image.yml
+++ b/config/install/field.field.node.landing_page_lb.field_meta_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_image
+    - media.type.image
+    - node.type.landing_page_lb
+id: node.landing_page_lb.field_meta_image
+field_name: field_meta_image
+entity_type: node
+bundle: landing_page_lb
+label: 'Meta image'
+description: 'An image associated with this page, for use as a thumbnail in social networks and other services. Images should be at least 1080px in width.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: changed
+      direction: DESC
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.node.landing_page_lb.field_meta_tags.yml
+++ b/config/install/field.field.node.landing_page_lb.field_meta_tags.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.landing_page_lb
+  module:
+    - metatag
+id: node.landing_page_lb.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: landing_page_lb
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/config/install/field.storage.node.field_meta_description.yml
+++ b/config/install/field.storage.node.field_meta_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_meta_description
+field_name: field_meta_description
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_meta_image.yml
+++ b/config/install/field.storage.node.field_meta_image.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_meta_image
+field_name: field_meta_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/metatag.metatag_defaults.node__landing_page_lb.yml
+++ b/config/install/metatag.metatag_defaults.node__landing_page_lb.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__landing_page_lb
+label: 'Content: Landing Page (Layout Builder)'
+tags:
+  description: '[node:field_meta_description]'
+  image_src: '[node:field_meta_image:entity:field_media_image]'
+  og_image: '[node:field_meta_image:entity:field_media_image:facebook]'
+  og_image_height: '[node:field_meta_image:entity:field_media_image:facebook:height]'
+  og_image_type: '[node:field_meta_image:entity:field_media_image:facebook:type]'
+  og_image_width: '[node:field_meta_image:entity:field_media_image:facebook:width]'

--- a/config/install/metatag.metatag_defaults.node__landing_page_lb.yml
+++ b/config/install/metatag.metatag_defaults.node__landing_page_lb.yml
@@ -8,5 +8,5 @@ tags:
   image_src: '[node:field_meta_image:entity:field_media_image]'
   og_image: '[node:field_meta_image:entity:field_media_image:facebook]'
   og_image_height: '[node:field_meta_image:entity:field_media_image:facebook:height]'
-  og_image_type: '[node:field_meta_image:entity:field_media_image:facebook:type]'
+  og_image_type: '[node:field_meta_image:entity:field_media_image:facebook:mimetype]'
   og_image_width: '[node:field_meta_image:entity:field_media_image:facebook:width]'

--- a/y_lb.info.yml
+++ b/y_lb.info.yml
@@ -15,6 +15,9 @@ dependencies:
   - drupal:layout_builder_restrictions
   - drupal:lb_claro
   - drupal:scheduler
+  - drupal:system
+  - drupal:user
+  - drupal:path
   - drupal:pathauto
   - drupal:field_group
   - drupal:metatag

--- a/y_lb.info.yml
+++ b/y_lb.info.yml
@@ -18,5 +18,5 @@ dependencies:
   - drupal:pathauto
   - drupal:field_group
   - drupal:metatag
-  - drupal:openy_focal_point
+  - openy_focal_point
 

--- a/y_lb.info.yml
+++ b/y_lb.info.yml
@@ -16,4 +16,7 @@ dependencies:
   - drupal:lb_claro
   - drupal:scheduler
   - drupal:pathauto
+  - drupal:field_group
+  - drupal:metatag
+  - drupal:openy_focal_point
 

--- a/y_lb.info.yml
+++ b/y_lb.info.yml
@@ -19,4 +19,5 @@ dependencies:
   - drupal:field_group
   - drupal:metatag
   - openy_focal_point
+  - drupal:openy_gtranslate
 

--- a/y_lb.install
+++ b/y_lb.install
@@ -178,3 +178,31 @@ function y_lb_update_9010(&$sandbox) {
     'core.entity_view_display.node.landing_page_lb.default',
   ]);
 }
+
+/**
+ * Add metadata helper fields and enable meta tags
+ */
+function y_lb_update_9011(&$sandbox) {
+  $configs = [
+    'core.entity_form_display.node.landing_page_lb.default',
+    'core.entity_view_display.node.landing_page_lb.default',
+    'field.field.node.landing_page_lb.field_meta_description',
+    'field.field.node.landing_page_lb.field_meta_image',
+    'field.field.node.landing_page_lb.field_meta_tags',
+    'field.storage.node.field_meta_description',
+    'field.storage.node.field_meta_image',
+  ];
+
+  // Only import the metatag config if it's not already configured.
+  $active_config = \Drupal::configFactory()->getEditable('metatag.metatag_defaults.node__landing_page_lb');
+  $settings = $active_config->get('tags');
+  if (!isset($settings)) {
+    $configs[] = 'metatag.metatag_defaults.node__landing_page_lb';
+  }
+
+  $path = \Drupal::service('extension.list.module')->getPath('y_lb') . '/config/install';
+  /** @var \Drupal\config_import\ConfigImporterService $config_importer */
+  $config_importer = \Drupal::service('config_import.importer');
+  $config_importer->setDirectory($path);
+  $config_importer->importConfigs($configs);
+}


### PR DESCRIPTION
resolves [DS-848](https://yusa.atlassian.net/browse/DS-848)

Adds a "Metadata" section to the Landing Page (Layout Builder) content type with two helper fields and lots of descriptions to help content editors make good words. Image and Description are fed into the proper meta and og tags.

![Edit_Landing_Page__Layout_Builder__Demo_Layout_Builder_page_-_Home___Drush_Site-Install](https://github.com/YCloudYUSA/y_lb/assets/238201/6bc96f64-7694-4d44-96c1-509959657002)
