### PR TITLE
DS-848 Resolve failed updates 

### DIFF
--- a/config/install/field.storage.node.field_meta_tags.yml
+++ b/config/install/field.storage.node.field_meta_tags.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - metatag
+    - node
+id: node.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: true
+custom_storage: false

--- a/y_lb.install
+++ b/y_lb.install
@@ -121,6 +121,13 @@ function y_lb_update_9005(&$sandbox) {
   $config_importer = \Drupal::service('config_import.importer');
   $config_importer->setDirectory($path);
   $config_importer->importConfigs([
+    'field.storage.node.field_meta_description',
+    'field.storage.node.field_meta_image',
+    'field.storage.node.field_meta_tags',
+    'field.field.node.landing_page_lb.field_meta_description',
+    'field.field.node.landing_page_lb.field_meta_image',
+    'field.field.node.landing_page_lb.field_meta_tags',
+    'core.entity_form_display.node.landing_page_lb.default',
     'core.entity_view_display.node.landing_page_lb.default',
   ]);
 }
@@ -175,6 +182,13 @@ function y_lb_update_9010(&$sandbox) {
   $config_importer = \Drupal::service('config_import.importer');
   $config_importer->setDirectory($path);
   $config_importer->importConfigs([
+    'field.storage.node.field_meta_description',
+    'field.storage.node.field_meta_image',
+    'field.storage.node.field_meta_tags',
+    'field.field.node.landing_page_lb.field_meta_description',
+    'field.field.node.landing_page_lb.field_meta_image',
+    'field.field.node.landing_page_lb.field_meta_tags',
+    'core.entity_form_display.node.landing_page_lb.default',
     'core.entity_view_display.node.landing_page_lb.default',
   ]);
 }
@@ -184,13 +198,14 @@ function y_lb_update_9010(&$sandbox) {
  */
 function y_lb_update_9011(&$sandbox) {
   $configs = [
-    'core.entity_form_display.node.landing_page_lb.default',
-    'core.entity_view_display.node.landing_page_lb.default',
+    'field.storage.node.field_meta_description',
+    'field.storage.node.field_meta_image',
+    'field.storage.node.field_meta_tags',
     'field.field.node.landing_page_lb.field_meta_description',
     'field.field.node.landing_page_lb.field_meta_image',
     'field.field.node.landing_page_lb.field_meta_tags',
-    'field.storage.node.field_meta_description',
-    'field.storage.node.field_meta_image',
+    'core.entity_form_display.node.landing_page_lb.default',
+    'core.entity_view_display.node.landing_page_lb.default',
   ];
 
   // Only import the metatag config if it's not already configured.


### PR DESCRIPTION
Because prior updates (`y_lb_update_9006, 9011`) import updated config those updates fail because the dependent config isn't imported:

> >  [error]  Configuration <em class="placeholder">core.entity_view_display.node.landing_page_lb.default</em> depends on configuration (<em class="placeholder">field.field.node.landing_page_lb.field_meta_description, field.field.node.landing_page_lb.field_meta_image, field.field.node.landing_page_lb.field_meta_tags</em>) that will not exist after import.

This update rewrites history ... but only if it hasn't been written yet. It adds the dependent config any time `core.entity_view_display.node.landing_page_lb.default` is imported so that updates can proceed. It doesn't matter where a site is when they update, they should now not run into config issues.