### PR TITLE
[Backport YN] Fix not loading bootstrap_styles/aos.local

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         },
         "patches": {
             "drupal/bootstrap_styles": {
-                "Issue #3330458: - [Drupal 10] Change of JS jquery/once to drupal core/once, migrate JS API": "https://www.drupal.org/files/issues/2023-03-07/bootstrap_styles-3330458-8.patch"
+                "Issue #3330458: - [Drupal 10] Change of JS jquery/once to drupal core/once, migrate JS API": "https://www.drupal.org/files/issues/2023-03-07/bootstrap_styles-3330458-8.patch",
+                "3315218 - Fix not loading bootstrap_styles/aos.local": "https://www.drupal.org/files/issues/2023-01-25/3315218-17--1-0-x.patch"
             },
             "drupal/bootstrap_layout_builder": {
                 "Issue #3335356: - Fix Module does not work in D10": "https://www.drupal.org/files/issues/2023-01-25/issue_3335356_drupal10.patch"


### PR DESCRIPTION
Backport from: https://github.com/ymcatwincities/yn/pull/6651
Fix logs: 
/srv/www/ygtc_github/releases/20230710060311/docroot/core/lib/Drupal/Core/Asset/LibraryDependencyResolver.php) #0 /srv/www/ygtc_github/releases/20230710060311/docroot/core/includes/bootstrap.inc(347): _drupal_error_handler_real(2, 'Undefined array...', '/srv/www/ygtc_g...', 67)