### PR TITLE
feat: remove patches, limit bootstrap_styles version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "require": {
         "cweagans/composer-patches": "*",
-        "drupal/bootstrap_styles": "*",
+        "drupal/bootstrap_styles": ">= 1.1.1",
         "drupal/bootstrap_layout_builder" : "*",
         "drupal/entity_clone": "^2.0@alpha || ^2",
         "drupal/layout_builder_blocks" : "*",
@@ -60,10 +60,6 @@
             }
         },
         "patches": {
-            "drupal/bootstrap_styles": {
-                "Issue #3330458: - [Drupal 10] Change of JS jquery/once to drupal core/once, migrate JS API": "https://www.drupal.org/files/issues/2023-03-07/bootstrap_styles-3330458-8.patch",
-                "3315218 - Fix not loading bootstrap_styles/aos.local": "https://www.drupal.org/files/issues/2023-01-25/3315218-17--1-0-x.patch"
-            },
             "drupal/bootstrap_layout_builder": {
                 "Issue #3335356: - Fix Module does not work in D10": "https://www.drupal.org/files/issues/2023-01-25/issue_3335356_drupal10.patch"
             }


### PR DESCRIPTION
Addresses: https://yusa.atlassian.net/browse/DS-911
Incorporates: https://www.drupal.org/project/bootstrap_styles/issues/3315218#comment-15168189
Incorporates: https://www.drupal.org/project/bootstrap_styles/issues/3330458#comment-15168188


Context:

```sh
composer why drupal/bootstrap_styles
drupal/bootstrap_layout_builder 2.1.1 requires drupal/bootstrap_styles (^1.1) 
drupal/layout_builder_blocks    1.1.0 requires drupal/bootstrap_styles (^1.1) 
ycloudyusa/y_lb                 2.0.2 requires drupal/bootstrap_styles (*) 
```

After the change

```sh
MacBook-Pro-Andrii:drupal10 podarok$ composer why drupal/bootstrap_styles
drupal/bootstrap_layout_builder 2.1.1                      requires drupal/bootstrap_styles (^1.1)     
drupal/layout_builder_blocks    1.1.0                      requires drupal/bootstrap_styles (^1.1)     
ycloudyusa/y_lb                 dev-fixed_bootstrap_styles requires drupal/bootstrap_styles (>= 1.1.1) 
MacBook-Pro-Andrii:drupal10 podarok$ composer show | grep bootstrap_styles
drupal/bootstrap_styles                   1.1.1                              Add a plugins builder and a collection of reusable plugins to the Layou...
ycloudyusa/y_lb                           dev-fixed_bootstrap_styles a5c51a6 Adds Layout Builder to Web Services project.
```