### PR TITLE
fix: DS-912 Add dependency to resolve config import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "drupal/y_facility" : "^1.0",
         "drupal/y_lb_article" : "^1.0 || ^1.1",
         "drupal/pathauto" : "^1.11",
+        "open-y-subprojects/openy_features": "*",
         "open-y-subprojects/openy_focal_point" : "^1.1",
         "php": ">=8.1"
     },

--- a/y_lb.info.yml
+++ b/y_lb.info.yml
@@ -22,5 +22,7 @@ dependencies:
   - drupal:field_group
   - drupal:metatag
   - openy_focal_point
+  - openy_media_image
+  - openy_menu_footer
   - drupal:openy_gtranslate
 


### PR DESCRIPTION
resolves https://yusa.atlassian.net/browse/DS-912

On config import this error occurs:

```
                                                                                                                                                                 
  [Drupal\Core\Config\UnmetDependenciesException]                                                                                                                
  Configuration objects provided by <em class="placeholder">y_lb</em> have unmet dependencies: <em class="placeholder">core.entity_form_display.node.landing_pa  
  ge_lb.default (entity_browser.browser.images_library), core.entity_view_display.node.landing_page_lb.default (system.menu.footer-menu-center, system.menu.foo  
  ter-menu-left, system.menu.footer-menu-right), field.field.node.landing_page_lb.field_meta_image (media.type.image)</em>                                       
```

this adds a bunch of direct dependencies with `openy_features`, but `openy_focal_point` already requires the whole `openy` package so this just makes it more direct.