### PR TITLE
Do not apply y_lb/main to every entity canonical page

### DIFF
--- a/y_lb.module
+++ b/y_lb.module
@@ -11,6 +11,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\block_content\BlockContentInterface;
 use Drupal\editor\Entity\Editor;
+use Drupal\layout_builder\Entity\LayoutBuilderEntityViewDisplay;
 use Drupal\layout_builder\Form\DefaultsEntityForm;
 use Drupal\layout_builder\Form\OverridesEntityForm;
 use Drupal\node\NodeInterface;
@@ -155,9 +156,34 @@ function y_lb_page_attachments_alter(array &$page) {
   }
 
   $route_match = \Drupal::routeMatch();
-  // Attach the libraries only in entity canonical route.
-  if (in_array($route_match->getRouteName(), $entity_canonical_routes)) {
-    // Attach the Y-LB main styles.
+  $current_route = $route_match->getRouteName();
+  // Attach the libraries only in entity canonical route and only when the
+  // Layout Builder is enabled for the view mode.
+  if (in_array($current_route, $entity_canonical_routes)) {
+    $current_route_exploded = explode('.', $current_route);
+    $route_entity_type_id = $current_route_exploded[1];
+
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $route_match->getParameter($route_entity_type_id);
+    // Do not apply the y_lb/main since we can't find the entity.
+    if (!$entity) {
+      return;
+    }
+    $bundle = $entity->bundle();
+
+    /** @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository */
+    $entity_display_repository = \Drupal::service('entity_display.repository');
+    $view_display = $entity_display_repository->getViewDisplay($route_entity_type_id, $bundle, 'full');
+
+    // Do not apply the y_lb/main since it's not a layout builder or it's not
+    // enabled.
+    if (
+      !$view_display instanceof LayoutBuilderEntityViewDisplay
+      || $view_display->isLayoutBuilderEnabled()
+    ) {
+      return;
+    }
+
     $page['#attached']['library'][] = 'y_lb/main';
   }
 }


### PR DESCRIPTION
If we update existing website with a lot of content the custom styling of https://github.com/YCloudYUSA/y_lb/blob/main/assets/scss/button.scss breaks the design for all non y_lb related pages.

This PR is aimed adjust the condition of applying the y_lb/main library.  Make sure the y_lb/main is applied only for canonical pages with Layout Builder enabled.

Please, review.