### PR TITLE
[DS-963] Add description for the CTA Block field

### DIFF
--- a/modules/y_lb_main_menu_cta_block/config/install/field.field.block_content.menu_cta.field_menu_cta_link.yml
+++ b/modules/y_lb_main_menu_cta_block/config/install/field.field.block_content.menu_cta.field_menu_cta_link.yml
@@ -11,7 +11,7 @@ field_name: field_menu_cta_link
 entity_type: block_content
 bundle: menu_cta
 label: 'Menu CTA Link'
-description: ''
+description: 'Note: <em>CTA block will be displayed only for the <b>1st level</b> of the menu links, all other levels will ignore CTA block displaying</em>'
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
- log in as admin
- click on the Extend button and install Website Services Main Menu CTA block module
- hover over Structure > Menus > click on the Main Navigation
- check that in the Menu Links (items) add/edit form description text has been added to the **CTA block** field