### PR TITLE
DS-1181 first lvl menu as link

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -90,7 +90,12 @@
       const header = $('.ws-header', context);
 
       $('.dropdown-submenu a.menu-link-item').click(function (e) {
-        if ($(this).parent().hasClass('children')) {
+        // If the item is already open, then go to the link.
+        if ($(this).parent().hasClass('active')) {
+          window.location.href = this.href;
+        }
+        // If the item is not open and it is a parent, then open it.
+        else if ($(this).parent().hasClass('children')) {
           e.stopPropagation();
           e.preventDefault();
         }
@@ -105,7 +110,7 @@
             $(this).removeClass('active');
           }
         });
-        
+
         // Set active 2nd level item and remove the state from siblings.
         $(this).parent().addClass('active').siblings().removeClass('active');
         if (header.hasClass('mobile')) {

--- a/templates/blb-section--y-lb.html.twig
+++ b/templates/blb-section--y-lb.html.twig
@@ -23,7 +23,7 @@
     {% for i in 1..12 %}
       {% set region = "blb_region_col_" ~ i %}
       {% if content[region] %}
-        <div {{ region_attributes[region].addClass('px-md-0') }}>
+        <div {{ region_attributes[region] }}>
           {{ content[region] }}
         </div>
       {% endif %}

--- a/templates/menu--main.html.twig
+++ b/templates/menu--main.html.twig
@@ -90,11 +90,17 @@
                 <a href="#" class="back">{{ navigationLinkLabel }}</a>
               </div>
               <div class="navigation-bottom">
-                {{ parent.title }}
+                <a href="{{ parent.url }}" class="main-menu-link--level-1">
+                  {{ parent.title }}
+                </a>
               </div>
             </div>
             <ul class="header-nav__submenu_links row-level-2">
-              <div class="dropdown-label">{{ parent.title }}</div>
+              <div class="dropdown-label">
+                <a href="{{ parent.url }}" class="main-menu-link--level-1">
+                  {{ parent.title }}
+                </a>
+              </div>
               {% for item in items %}
                 {% if item.below %}
                   {% set ia = item.attributes.addClass(['nav-level-3 children dropdown-submenu menu-item-' ~ item.title|clean_class]) %}
@@ -144,7 +150,9 @@
               <a href="#" class="back">{{ first_level_label }}</a>
             </div>
             <div class="navigation-bottom">
-              {{ parent.title }}
+              <a href="{{ parent.url }}" class="main-menu-link--level-1">
+                {{ parent.title }}
+              </a>
             </div>
           </div>
           <ul class="header-nav__submenu_links row-level-3">

--- a/y_lb.libraries.yml
+++ b/y_lb.libraries.yml
@@ -45,7 +45,7 @@ footer:
       assets/css/footer.css: { preprocess: true }
 
 header:
-  version: 1.12
+  version: 1.13
   css:
     component:
       assets/css/header.css: { preprocess: true }
@@ -153,4 +153,3 @@ button_position.overlapping:
   css:
     theme:
       assets/css/button-position-overlapping.css: { minified: false }
-


### PR DESCRIPTION
This adds on to @aleevas's solution by ensuring that second-level links are accessible, by actually going to their url if they are active.

Also re-adds gutters for multi-column sections. After removing the `px-md-0` class, here's how it looks:

![Demo_-_Programs_Overview___YMCA_OF__SPRINGFIELD_](https://github.com/YCloudYUSA/y_lb/assets/238201/b148c520-04a3-40a7-b1e6-1f53b02a616b)


Closes #173 