### PR TITLE
Deprecated function: unserialize() fix

### DIFF
--- a/src/Form/YLBOverridesEntityForm.php
+++ b/src/Form/YLBOverridesEntityForm.php
@@ -16,7 +16,13 @@ class YLBOverridesEntityForm extends OverridesEntityForm {
    */
   public function buildForm(array $form, FormStateInterface $form_state, SectionStorageInterface $section_storage = NULL) {
     $node = $this->entity;
-    $settings = $node->styles->value ? unserialize($node->styles->value) : [];
+
+    /** @var \Drupal\Core\Field\FieldItemList $styles */
+    $styles = $node->styles;
+    $settings = [];
+    if (!$styles->isEmpty()) {
+      $settings = unserialize($styles->value);
+    }
 
     $view_display = $this->entityTypeManager
       ->getStorage('entity_view_display')


### PR DESCRIPTION
Steps to reproduce:
1. Enable **y_lb** module.
2. Create the **Landing Page (Layout Builder)** node.
3. Navigate to the node layout page. Observe the error:

```
Deprecated function: unserialize(): Passing null to parameter #1 ($data) of type string is deprecated in Drupal\y_lb\Form\YLBOverridesEntityForm->buildForm() (line 22 of /var/www/docroot/modules/contrib/y_lb/src/Form/YLBOverridesEntityForm.php)
```