### PR TITLE
Checks if the library key is set and fixes an error message in y_lb.module

### DIFF
--- a/y_lb.module
+++ b/y_lb.module
@@ -369,7 +369,7 @@ function y_lb_preprocess_page(&$variables) {
  */
 function y_lb_preprocess_html(array &$variables) {
   //  Override .placeholder styles from bootstrap 5
-  if (isset($variables['#attached']) && is_array($variables['#attached']['library'])) {
+  if (isset($variables['#attached']['library']) && is_array($variables['#attached']['library'])) {
     if (in_array('ckeditor_bootstrap_buttons/bootstrap-5-js', $variables['#attached']['library'])) {
       $variables['#attached']['library'][] = 'y_lb/override';
     }


### PR DESCRIPTION
Checks if the library key is set and fixes the following error message:

Error message
Warning: Undefined array key "library" in y_lb_preprocess_html() (line 372 of modules/contrib/y_lb/y_lb.module).
![Screenshot 2023-12-08 at 17 57 35](https://github.com/YCloudYUSA/y_lb/assets/10885798/052e8acd-c1e9-41e9-90bb-2973e1a3c979)

Drupal 10.0.11
PHP version: 8.1.14