### PR TITLE
fix: Default styles are not appearing on switchable content types

### DIFF
--- a/src/Form/YLBOverridesEntityForm.php
+++ b/src/Form/YLBOverridesEntityForm.php
@@ -28,7 +28,7 @@ class YLBOverridesEntityForm extends OverridesEntityForm {
       $view_display = $this->entityTypeManager
         ->getStorage('entity_view_display')
         ->load('node.' . $node->bundle() . '.full');
-      $global_settings = $view_display->getThirdPartySettings('y_lb');
+      $global_settings = $view_display?->getThirdPartySettings('y_lb');
     }
     
     $default_settings = $global_settings['styles'] ?? [];

--- a/src/Form/YLBOverridesEntityForm.php
+++ b/src/Form/YLBOverridesEntityForm.php
@@ -22,6 +22,15 @@ class YLBOverridesEntityForm extends OverridesEntityForm {
       ->getStorage('entity_view_display')
       ->load('node.' . $node->bundle() . '.default');
     $global_settings = $view_display->getThirdPartySettings('y_lb');
+    
+    // If the default view mode does not have settings, try full.
+    if (!$global_settings) {
+      $view_display = $this->entityTypeManager
+        ->getStorage('entity_view_display')
+        ->load('node.' . $node->bundle() . '.full');
+      $global_settings = $view_display->getThirdPartySettings('y_lb');
+    }
+    
     $default_settings = $global_settings['styles'] ?? [];
 
     $form['ws_settings_container'] = [


### PR DESCRIPTION
As flagged on the YNCR project, default styles do not show up for "switchable" content types (Branch, Camp, Camp Subpage, Facility).

## Test steps:
- log in as admin
- create Branch, Camp, Camp Subpage and Facility content types with layout Builder enabled
- open layout builder 
- click on the override styles button and check if styles are enabled by default

![SCR-20240315-nuxg](https://github.com/YCloudYUSA/y_lb/assets/238201/3f7a95da-c93c-45e5-8a22-94f0fc3eff02)

## Expected behavior:
- Styles are enabled in LB for Branch, Camp, Camp Subpage and Facility content types

## Actual behavior: 
- Styles aren't enabled in LB for Branch, Camp, Camp Subpage and Facility content types

