### PR TITLE
[DS-1428] Disable 'openy_carnation/matchheight' library for page with LB

### DIFF
--- a/y_lb.module
+++ b/y_lb.module
@@ -187,6 +187,11 @@ function y_lb_page_attachments_alter(array &$page) {
     }
 
     $page['#attached']['library'][] = 'y_lb/main';
+
+    // Remove MatchHeight library for LB pages.
+    if (($key = array_search('openy_carnation/matchheight', $page['#attached']['library'])) !== FALSE) {
+      unset($page['#attached']['library'][$key]);
+    }
   }
 }
 


### PR DESCRIPTION
Jira issue - [DS-1428](https://yusa.atlassian.net/browse/DS-1428)

### Steps for review
- go to homepage
- open the Network tab in the Browser DevTools
- verify that the matchheight.js library **is not** attached
![image](https://github.com/YCloudYUSA/y_lb/assets/744406/4be4e31f-1ea2-454f-899e-2040de7af418)
- go to /legacy-home-page
- verify that the matchheight.js library **is** attached