### PR TITLE
[DS-1506] Select image window isn't visible until the user clicks on …

### DIFF
--- a/assets/scss/layout-builder.scss
+++ b/assets/scss/layout-builder.scss
@@ -557,6 +557,9 @@ figure.drupal-media.ck-widget {
   }
 }
 .ui-dialog {
+  &.entity-browser-modal {
+    top: 8% !important;
+  }
 
   .select-wrapper {
     &:before {

--- a/y_lb.libraries.yml
+++ b/y_lb.libraries.yml
@@ -1,5 +1,5 @@
 layout_builder:
-  version: 1.22
+  version: 1.23
   css:
     theme:
       assets/css/layout-builder.css: { minified: false, weight: 1001 }


### PR DESCRIPTION
Steps to Reproduce
 
- log in as admin
- create a Landing page LB
- add e.g Grid CTA block
- click on the Add media button
- click on the screen

**Actual Result**
Select image window isn’t visible until the user clicks on the screen.

**Expected Behaviour**
Select image window is displayed right after the user clicks on the Add media button

