### PR TITLE
fix: Add core patch to check maxwidth of textareas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
             },
             "drupal/core": {
                 "Issue #2922677: Uncaught TypeError: Cannot read property 'replace' of undefined": "https://www.drupal.org/files/issues/2023-02-15/2922677-33.patch",
-                "https://dgo.re/3049332 LB Call to a member function getEntityTypeId() on null": "https://www.drupal.org/files/issues/2024-03-11/drupal-core--2024-01-09--3049332-87.patch"
+                "https://dgo.re/3049332 LB Call to a member function getEntityTypeId() on null": "https://www.drupal.org/files/issues/2024-03-11/drupal-core--2024-01-09--3049332-87.patch",
+                "https://dgo.to/3344041 Allow textarea widgets to be used for text (formatted) fields (and check maxlength)": "https://www.drupal.org/files/issues/2023-02-23/3344041-text-formatted-field-use-textarea-widget.patch"
             }
         }
     }


### PR DESCRIPTION
## Issue

Adding over 255 characters to a “Section subtitle” field (where the field is displayed as a textarea) results in a WSOD on page save.


## Background

`id: block_content.field_section_subtitle` is defined in 10 different components, but in 7 places it’s defined as string and in three it’s string_long. Somehow just based on the order that modules get installed, the string definition takes precedence, but some components still display the field with the string_textarea widget, which doesn’t do a maxlength check. So… when users try to save more than 255 characters in a field that doesn’t support it AND doesn’t check the length, the site barfs, with something like:

> Drupal\Core\Entity\EntityStorageException: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column ‘field_section_subtitle_value’

The patch from https://www.drupal.org/project/drupal/issues/3344041#comment-14938134 adds a maxlength check on the field, and I think that’s a good quick fix, but ultimately I think we need to decide if the subtitle should be limited or not and make all of the components consistent.