### PR TITLE
DS-1544: Fixed the when click on parent item redirection to homepage.

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -92,8 +92,8 @@
       $('.dropdown-submenu .menu-link-item').click(function (e) {
         // If the item is already open, then go to the link.
         let parentLink = $(this).parent();
-        if ($(this).href !== undefined && parentLink.hasClass('active') ) {
-          window.location.href = $(this).href;
+        if ($(this).attr('href') !== undefined && parentLink.hasClass('active') ) {
+          window.location.href = $(this).attr('href');
         }
         // If the item is not open and it is a parent, then open it.
         else if (parentLink.hasClass('children')) {


### PR DESCRIPTION
- [ ] -   log as admin/ siteowner
- [ ] -  go to edit main menu /admin/structure/menu/manage/main
- [ ] -  edit the first level item of the menu (for ex. Programs)
- [ ] -  in the Link field , please, add and submit the form
- [ ] -  edit the second level item of the menu (ex. Programs => Youth Sports)
- [ ] -  in the Link field , please, add some reference link and submit the form
- [ ] -  go to home page
- [ ] -  click on Programs menu item and verify that the menu looks and works the same way as with a real link
- [ ] -  For parent item, observe first click open the child menu items, second click should redirect to its respective link.