### PR TITLE
DS-1574 fix: Add patches and updates to enable sub-item cloning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,12 @@
                 "Issue #2922677: Uncaught TypeError: Cannot read property 'replace' of undefined": "https://www.drupal.org/files/issues/2023-02-15/2922677-33.patch",
                 "https://dgo.re/3049332 LB Call to a member function getEntityTypeId() on null": "https://www.drupal.org/files/issues/2024-03-11/drupal-core--2024-01-09--3049332-87.patch",
                 "https://dgo.to/3344041 Allow textarea widgets to be used for text (formatted) fields (and check maxlength)": "https://www.drupal.org/files/issues/2023-02-23/3344041-text-formatted-field-use-textarea-widget.patch"
+            },
+            "drupal/inline_entity_form": {
+                "https://dgo.to/3002175 Custom blocks created in inline forms should not be reusable": "https://www.drupal.org/files/issues/2024-04-18/3002175-2.x-47.patch"
+            },
+            "drupal/entity_clone": {
+                "https://dgo.to/3050027 Inline Blocks on Layout Builder Fail to Clone Correctly": "https://www.drupal.org/files/issues/2023-08-14/3050027-62.patch"
             }
         }
     }

--- a/src/Config/YlbOverrides.php
+++ b/src/Config/YlbOverrides.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\y_lb\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Y LB configuration override.
+ */
+class YlbOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * The module handler to invoke the alter hook.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Creates the YlbOverrides object.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $overrides = [];
+    if ($this->moduleHandler->moduleExists('entity_clone')) {
+      $overrides['entity_clone.settings'] = [
+        'form_settings' => [
+          'block_content' => [
+            'default_value' => TRUE,
+            'disable' => TRUE,
+          ],
+        ],
+        'hide_layout_builder_referenced_entities' => TRUE,
+      ];
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'YlbOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/y_lb.install
+++ b/y_lb.install
@@ -4,6 +4,7 @@
  * @file
  */
 
+use Drupal\Core\Config\Config;
 use Drupal\Core\Field\BaseFieldDefinition;
 
 /**
@@ -275,4 +276,73 @@ function y_lb_update_9015(&$sandbox) {
     'core.entity_form_display.node.landing_page_lb.default',
     'node.type.landing_page_lb'
   ]);
+}
+
+/**
+ * Set blocks that should not be reusable to non-reusable.
+ */
+function y_lb_update_9017(&$sandbox) {
+  $sub_item_types = [
+    'accordion_item',
+    'card_item',
+    'carousel_item',
+    'donate_item',
+    'grid_item',
+    'icon_grid_item',
+    'lb_partner_item',
+    'lb_staff_member_item',
+    'statistics_item',
+    'tab_item',
+    'testimonial_item'
+  ];
+
+  $count = 0;
+  $block_storage = \Drupal::service('entity_type.manager')->getStorage('block_content');
+  $ids = \Drupal::entityQuery('block_content')
+    ->condition('type', $sub_item_types, 'IN')
+    ->condition('reusable', '1', '=')
+    ->accessCheck(FALSE)
+    ->execute();
+  foreach ($ids as $id) {
+    // Loop through blocks and set them to non-reusable.
+    /** @var \Drupal\block_content\Entity\BlockContent $updated */
+    $block = $block_storage->load($id);
+    $updated = $block->setNonReusable()->save();
+    if ($updated == 2) {
+      $count++;
+    }
+  }
+  \Drupal::messenger()
+    ->addMessage(t('Updated @count blocks.', [
+      '@count' => $count,
+    ]));
+}
+
+/**
+ * Update configuration with new handler from patch.
+ */
+function y_lb_update_9018() {
+  $blocks_with_sub_types = [
+    'field.field.block_content.lb_accordion.field_block_item',
+    'field.field.block_content.lb_cards.field_block_item',
+    'field.field.block_content.lb_carousel.field_block_item',
+    'field.field.block_content.lb_donate.field_block_item',
+    'field.field.block_content.lb_grid_cta.field_block_item',
+    'field.field.block_content.lb_icon_grid.field_block_item',
+    'field.field.block_content.lb_partners.field_partners',
+    'field.field.block_content.lb_staff_members.field_staff_members',
+    'field.field.block_content.lb_statistics.field_block_item',
+    'field.field.block_content.lb_tabs.field_block_item',
+    'field.field.block_content.lb_testimonials.field_testimonial_item'
+  ];
+
+  $config_factory = \Drupal::configFactory();
+
+  foreach ($blocks_with_sub_types as $block_field_config) {
+    $config = $config_factory->getEditable($block_field_config);
+    if ($config instanceof Config) {
+      $config->set('settings.handler', 'inline_entity_form');
+      $config->save(TRUE);
+    }
+  }
 }

--- a/y_lb.services.yml
+++ b/y_lb.services.yml
@@ -9,3 +9,8 @@ services:
   plugin.manager.ws_style_option:
     class: Drupal\y_lb\WSStyleOptionManager
     arguments: [ '@module_handler', '@cache.discovery', '@extension.path.resolver', '@file_url_generator' ]
+  y_lb.overrider:
+    class: Drupal\y_lb\Config\YlbOverrides
+    tags:
+      - {name: config.factory.override}
+    arguments: ['@module_handler']


### PR DESCRIPTION
- Create a new LB page with Cards (demo content won’t work because sometimes it’s not editable)
- Clone the LB page
- Edit one of the Cards on the cloned page
- Save the card and the page layout

Expected results:
- Editing cloned items changes the items on the cloned page but not the parent page. 
- This can be repeated with any other content type with subitems:
  - lb_accordion
  - lb_cards
  - lb_carousel
  - lb_donate
  - lb_grid_cta
  - lb_icon_grid
  - lb_partners
  - lb_staff_members
  - lb_statistics
  - lb_tabs
  - lb_testimonials 