### PR TITLE
DS-1583 fix: Allow CTA Menu Block to reference existing blocks

### DIFF
--- a/modules/y_lb_main_menu_cta_block/config/optional/core.entity_form_display.menu_link_content.main.default.yml
+++ b/modules/y_lb_main_menu_cta_block/config/optional/core.entity_form_display.menu_link_content.main.default.yml
@@ -24,7 +24,7 @@ content:
       label_singular: ''
       label_plural: ''
       allow_new: true
-      allow_existing: false
+      allow_existing: true
       match_operator: CONTAINS
       allow_duplicate: false
       collapsible: false

--- a/modules/y_lb_main_menu_cta_block/y_lb_main_menu_cta_block.install
+++ b/modules/y_lb_main_menu_cta_block/y_lb_main_menu_cta_block.install
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Install, update and uninstall functions for the Website Services Main Menu CTA block module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function y_lb_main_menu_cta_block_install(): void {
+  \Drupal::messenger()->addStatus(t('Module Website Services Main Menu CTA block has been installed.'));
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function y_lb_main_menu_cta_block_uninstall(): void {
+  \Drupal::messenger()->addStatus(t('Module Website Services Main Menu CTA block has been uninstalled.'));
+}
+
+/**
+ * Allow CTA Block field to reference existing blocks.
+ */
+function y_lb_main_menu_cta_block_update_10001(): void
+{
+  $config = \Drupal::service('extension.list.module')->getPath('y_lb_main_menu_cta_block') . '/config/optional/core.entity_form_display.menu_link_content.main.default.yml';
+  $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
+  $config_importer->update($config, 'core.entity_form_display.menu_link_content.main.default', 'content.field_cta_block.settings.allow_existing');
+}

--- a/modules/y_lb_main_menu_cta_block/y_lb_main_menu_cta_block.install
+++ b/modules/y_lb_main_menu_cta_block/y_lb_main_menu_cta_block.install
@@ -8,20 +8,6 @@ declare(strict_types=1);
  */
 
 /**
- * Implements hook_install().
- */
-function y_lb_main_menu_cta_block_install(): void {
-  \Drupal::messenger()->addStatus(t('Module Website Services Main Menu CTA block has been installed.'));
-}
-
-/**
- * Implements hook_uninstall().
- */
-function y_lb_main_menu_cta_block_uninstall(): void {
-  \Drupal::messenger()->addStatus(t('Module Website Services Main Menu CTA block has been uninstalled.'));
-}
-
-/**
  * Allow CTA Block field to reference existing blocks.
  */
 function y_lb_main_menu_cta_block_update_10001(): void


### PR DESCRIPTION
To test:

- go to `/admin/structure/menu/manage/main`
- edit a menu item
- observe "Add existing content block"
- 
![SCR-20240724-pbcv](https://github.com/user-attachments/assets/3d4425b9-5cb5-4968-85f4-5183027fcf64)
