### PR TITLE
DS-1279 Enable y_lb support on taxonomy pages

### DIFF
--- a/src/Plugin/Block/NodeTagsBlock.php
+++ b/src/Plugin/Block/NodeTagsBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\y_lb\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\CurrentRouteMatch;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -67,17 +68,47 @@ class NodeTagsBlock extends BlockBase implements ContainerFactoryPluginInterface
   /**
    * {@inheritdoc}
    */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+
+    $config = $this->getConfiguration();
+
+    $form['display_as_links'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Display as links'),
+      '#default_value' => isset($config['display_as_links']) ? $config['display_as_links'] : FALSE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    parent::blockSubmit($form, $form_state);
+
+    $this->setConfigurationValue('display_as_links', $form_state->getValue('display_as_links'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function build() {
     if (!$this->node || !$this->node->hasField('field_tags')) {
       return [];
     }
 
+    $config = $this->getConfiguration();
+    $link = !empty($config['display_as_links']);
+
     $build['tags'] = $this->node->get('field_tags')->view([
       'label' => 'hidden',
       'settings' => [
-        'link' => FALSE,
+        'link' => $link,
       ],
     ]);
+
     return $build;
   }
 

--- a/y_lb.module
+++ b/y_lb.module
@@ -19,6 +19,7 @@ use Drupal\layout_builder\Form\DefaultsEntityForm;
 use Drupal\layout_builder\Form\OverridesEntityForm;
 use Drupal\layout_builder\Plugin\SectionStorage\OverridesSectionStorage;
 use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\y_lb\Form\YLBEntityViewDisplay;
 use Drupal\y_lb\Form\YLBOverridesEntityForm;
 
@@ -327,14 +328,24 @@ function y_lb_entity_base_field_info(EntityTypeInterface $entity_type) {
 }
 
 /**
- * Implements hook_preprocess_HOOK() for nodes.
+ * Implements hook_preprocess_HOOK() for pages.
  */
-function y_lb_preprocess_node(&$variables) {
+function y_lb_preprocess_page(&$variables) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'] ?? NULL;
 
-  // Skip page without node.
-  if (!$node instanceof NodeInterface) {
+  // Will be "true" if you are currently on a taxonomy term page.
+  if (\Drupal::routeMatch()->getRouteName() == 'entity.taxonomy_term.canonical') {
+
+    // Since this is a taxonomy term page, you may wish to get the term ID.
+    $term_id = \Drupal::routeMatch()->getRawParameter('taxonomy_term');
+
+    // Load the term object.
+    $node = Term::load($term_id);
+  }
+
+  // Skip page without node or term.
+  if ((!$node instanceof NodeInterface) && (!$node instanceof Term)) {
     return;
   }
   // Skip nodes without LB usage.
@@ -355,7 +366,7 @@ function y_lb_preprocess_node(&$variables) {
   /** @var \Drupal\y_lb\WSStyleOptionManager $ws_style_options */
   $ws_style_option = \Drupal::service('plugin.manager.ws_style_option');
   // Check individual node for overridden Y Styles.
-  if ($node->override_styles->value) {
+  if ($node->override_styles && $node->override_styles->value) {
     $styles = unserialize($node->styles->value);
   }
   else {
@@ -363,7 +374,7 @@ function y_lb_preprocess_node(&$variables) {
     foreach (['full', 'default'] as $display) {
       $view_display = \Drupal::entityTypeManager()
         ->getStorage('entity_view_display')
-        ->load('node.' . $node->bundle() . '.' . $display);
+        ->load($node->getEntityTypeId() . '.' . $node->bundle() . '.' . $display);
       if (!$view_display) {
         continue;
       }

--- a/y_lb.module
+++ b/y_lb.module
@@ -327,9 +327,9 @@ function y_lb_entity_base_field_info(EntityTypeInterface $entity_type) {
 }
 
 /**
- * Implements hook_preprocess_HOOK() for pages.
+ * Implements hook_preprocess_HOOK() for nodes.
  */
-function y_lb_preprocess_page(&$variables) {
+function y_lb_preprocess_node(&$variables) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $variables['node'] ?? NULL;
 


### PR DESCRIPTION
https://yusa.atlassian.net/browse/DS-1279

y_lb only works for content pages. If we want to use y_lb in other place like term pages or other system-generated things, we need to add additional logic. This allows y_lb to included on other types of entity types where Layout Builder might be enabled. 

Also adds a "Display as link" option for the Tags block. This is off by default.