### PR TITLE
[DS-1754] Rename WS Settings

### DIFF
--- a/y_lb.links.menu.yml
+++ b/y_lb.links.menu.yml
@@ -1,5 +1,6 @@
 y_lb.admin:
-  title: 'WS settings'
+  title: 'Y Layout Builder settings'
+  description: 'Configure settings for Y Layout Builder pages.'
   parent: openy_system.openy_settings
   route_name: y_lb.settings
   weight: 0

--- a/y_lb.routing.yml
+++ b/y_lb.routing.yml
@@ -2,6 +2,6 @@ y_lb.settings:
   path: '/admin/openy/settings/y-lb'
   defaults:
     _form: '\Drupal\y_lb\Form\SettingsForm'
-    _title: 'WS settings'
+    _title: 'Y Layout Builder settings'
   requirements:
     _permission: 'administer site configuration'


### PR DESCRIPTION
https://yusa.atlassian.net/browse/DS-1754

> It seems we’ve built two new settings pages now… under YMCA WS > Settings there is now “Small Y Settings” and “WS Settings”… neither of those is particularly clear in what they do.

> Let’s consider renaming these items to provide more clarity for administrative end users.

"WS Settings" was set in this module, this changes that to "Y Layout Builder settings" which makes it a little more clear that these settings are for LB pages.