### PR TITLE
Update SiteLogoBlock.php

### DIFF
--- a/src/Plugin/Block/SiteLogoBlock.php
+++ b/src/Plugin/Block/SiteLogoBlock.php
@@ -193,7 +193,7 @@ class SiteLogoBlock extends BlockBase implements ContainerFactoryPluginInterface
     $build['#logo_url'] = theme_get_setting('logo.path') ?
       $this->fileUrlGenerator->generateAbsoluteString(theme_get_setting('logo.path'))
       : '';
-    $build['#transparent_logo_url'] = $build['mobile_logo_url'] = $build['#logo_url'];
+    $build['#transparent_logo_url'] = $build['#mobile_logo_url'] = $build['#logo_url'];
 
     if ($build['#logo_url']) {
       $this->ylbPreprocessSvgLogo($build);


### PR DESCRIPTION
When the theme logo is used in a carnation subtheme, this error is thrown:

> User error: "mobile_logo_url" is an invalid render array key in Drupal\Core\Render\Element::children() (line 98 of core/lib/Drupal/Core/Render/Element.php).