### PR TITLE
Fix external links not working in main navigation menu

### DIFF
--- a/templates/menu--main.html.twig
+++ b/templates/menu--main.html.twig
@@ -50,7 +50,9 @@
               {% elseif item.url.options.attributes.class %}
                 {% set nav_link_classes = nav_link_classes|merge([item.url.options.attributes.class]) %}
               {% endif %}
-              {% if item.url.isRouted and item.url.routeName not in ['<nolink>', '<none>'] %}
+              {% if item.url.toString starts with 'http' or item.url.toString starts with 'https' %}
+                {% set menu_item_href = 'href=' ~ item.url.toString %}
+              {% elseif item.url.isRouted and item.url.routeName not in ['<nolink>', '<none>'] %}
                 {% set menu_item_href = "href=#{item.url|render}" %}
               {% else %}
                 {% set menu_item_href = '' %}


### PR DESCRIPTION
_Problem:_ External menu links not working in main navigation

- Updated menu template logic to properly handle non-routed (external) links. 
- Previously, only routed links were generating href attributes, causing external links to be non-functional. 
- This update ensures that both routed and external links are correctly rendered in the navigation.