### PR TITLE
fix: desktop dropdown menu

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -134,6 +134,28 @@
       const firstLevelItem = $('.header-nav__links .dropdown', context);
       const firstLevelItemLink = $(firstLevelItem, context).children('a');
       $(firstLevelItemLink, context).click(function (e) {
+        // Handle desktop dropdown for parent items with children
+        if (header.hasClass('desktop') && $(this).parent().hasClass('children')) {
+          e.preventDefault();
+          e.stopPropagation();
+          const $parent = $(this).parent();
+          const $subMenu = $(this).siblings('.header-nav__submenu');
+
+          // Close other open dropdowns
+          $('.header-nav__links .dropdown').not($parent).removeClass('show');
+          $('.header-nav__submenu').not($subMenu).removeClass('show').css('display', '');
+
+          // Toggle current dropdown
+          $parent.toggleClass('show');
+          $subMenu.toggleClass('show');
+
+          // Force display with inline style if needed
+          if ($subMenu.hasClass('show')) {
+            $subMenu.css('display', 'flex');
+          } else {
+            $subMenu.css('display', '');
+          }
+        }
         if (header.hasClass('mobile')) {
           if ($(this).parent().hasClass('children')) {
             e.preventDefault();
@@ -185,6 +207,21 @@
           headerSubMenu.removeClass('open');
           headerSubMenu.removeClass('show');
           $('.dropdown').removeClass('show');
+        }
+      });
+      // Close dropdown when clicking outside (desktop only)
+      $(document).click(function (e) {
+        if (header.hasClass('desktop')) {
+          const $target = $(e.target);
+          // This prevents immediate close when opening dropdown
+          if ($target.closest('.dropdown.children > a').length > 0) {
+            return;
+          }
+          // If click is not on menu or inside dropdown
+          if (!$target.closest('.header-nav__links').length) {
+            $('.header-nav__links .dropdown').removeClass('show');
+            $('.header-nav__submenu').removeClass('show').css('display', '');
+          }
         }
       });
       // Set top position for submenus in mobile screen.


### PR DESCRIPTION
## Problem/Issue Summary

The desktop dropdown menu in the y_lb module has two related issues:

### Issue 1: Parent menu items navigate instead of opening dropdown
When clicking on a parent menu item that has children, the browser navigates to the parent item's URL instead of opening the dropdown menu. This prevents users from seeing and accessing child menu items.

### Issue 2: Dropdown doesn't close when clicking outside
The dropdown menu doesn't close when clicking anywhere outside the menu area, forcing users to click on another menu item to close it.

**Current behavior:**
- Click on parent item → navigates to parent URL (users can't see children) ✗
- Dropdown doesn't close when clicking outside menu ✗

**Expected behavior:**
- Click on parent item → open/close dropdown (toggle) ✓
- Click on different parent item → close previous, open new ✓
- Click anywhere outside menu → close dropdown ✓
- Parent link should not navigate when item has children ✓