### PR TITLE
feat(ITCR-1107): Add global table styles for CKEditor content

### DIFF
--- a/assets/css/tables.css
+++ b/assets/css/tables.css
@@ -1,0 +1,76 @@
+/**
+ * @file
+ * Global table styles for CKEditor content.
+ *
+ * These styles apply to all tables created via CKEditor Insert Table feature
+ * across all Layout Builder components and content types.
+ */
+
+/* Apply to all formatted text fields that may contain CKEditor tables */
+.field-item table,
+.tab-content table,
+.lb-table table,
+.text-formatted table,
+.field--type-text-with-summary table,
+.field--type-text-long table {
+  width: 100%;
+  border: none;
+  border-collapse: collapse;
+  margin: 1em 0;
+}
+
+.field-item table thead tr,
+.tab-content table thead tr,
+.lb-table table thead tr,
+.text-formatted table thead tr,
+.field--type-text-with-summary table thead tr,
+.field--type-text-long table thead tr {
+  border: none;
+  border-bottom: 5px solid var(--ylb-color-grey-2, #cccccc);
+}
+
+.field-item table thead tr th,
+.tab-content table thead tr th,
+.lb-table table thead tr th,
+.text-formatted table thead tr th,
+.field--type-text-with-summary table thead tr th,
+.field--type-text-long table thead tr th {
+  border: none;
+  font-size: 22px;
+  line-height: 32px;
+  padding: 15px 0.5em;
+  font-weight: bold;
+}
+
+@media (min-width: 992px) {
+  .field-item table thead tr th,
+  .tab-content table thead tr th,
+  .lb-table table thead tr th,
+  .text-formatted table thead tr th,
+  .field--type-text-with-summary table thead tr th,
+  .field--type-text-long table thead tr th {
+    font-size: 24px;
+    line-height: 36px;
+  }
+}
+
+.field-item table tbody tr,
+.tab-content table tbody tr,
+.lb-table table tbody tr,
+.text-formatted table tbody tr,
+.field--type-text-with-summary table tbody tr,
+.field--type-text-long table tbody tr {
+  border-bottom: 2px solid var(--ylb-color-light-grey-3, #e0e0e0);
+}
+
+.field-item table tbody tr td,
+.tab-content table tbody tr td,
+.lb-table table tbody tr td,
+.text-formatted table tbody tr td,
+.field--type-text-with-summary table tbody tr td,
+.field--type-text-long table tbody tr td {
+  border: none;
+  font-size: 18px;
+  line-height: 28px;
+  padding: 20px 0.5em !important;
+}

--- a/assets/css/tables.css
+++ b/assets/css/tables.css
@@ -72,5 +72,5 @@
   border: none;
   font-size: 18px;
   line-height: 28px;
-  padding: 20px 0.5em !important;
+  padding: 20px 0.5em;
 }

--- a/y_lb.libraries.yml
+++ b/y_lb.libraries.yml
@@ -10,13 +10,14 @@ layout_builder:
     - core/jquery
 
 main:
-  version: 1.37
+  version: 1.38
   css:
     theme:
       assets/css/colors.css: { minified: false }
       assets/css/typography.css: { minified: false }
       assets/css/page.css: { minified: false }
       assets/css/button.css: { minified: false }
+      assets/css/tables.css: { minified: false }
   js:
     assets/js/mobile_tables.js: { }
   dependencies:


### PR DESCRIPTION
Add consistent table styling across all Layout Builder components to ensure tables created via CKEditor Insert Table feature have uniform appearance regardless of the component they're placed in.

Changes:
- Add assets/css/tables.css with global table styles
- Update y_lb.libraries.yml to include tables.css in main library
- Bump main library version from 1.37 to 1.38

The styles apply to:
- Simple Text/Table component (lb_table)
- Tabs component (tab-content)
- Cards, Banner, and all other LB components with text fields
- All field types: text-with-summary, text-long, formatted text

Table styling includes:
- thead: 5px border-bottom, 22-24px font-size, bold
- tbody: 2px border-bottom, 18px font-size, 20px padding
- Responsive design with desktop breakpoint at 992px
- Uses CSS variables for colors (ylb-color-grey-2, ylb-color-light-grey-3)

Before (Tab component)
<img width="730" height="367" alt="image" src="https://github.com/user-attachments/assets/cb0c9bcc-0894-47d4-a71d-f7d8da5f9667" />

After:
<img width="762" height="447" alt="image" src="https://github.com/user-attachments/assets/2aef88f4-7984-44cd-b60b-db955470f1b5" />
