### PR TITLE
fix(ITCR-1107): Remove .field-item table selector from global table styles

### DIFF
--- a/assets/css/tables.css
+++ b/assets/css/tables.css
@@ -7,6 +7,7 @@
  */
 
 /* Apply to all formatted text fields that may contain CKEditor tables */
+.field-branch-hours table,
 .tab-content table,
 .lb-table table,
 .text-formatted table,
@@ -18,6 +19,7 @@
   margin: 1em 0;
 }
 
+.field-branch-hours table thead tr,
 .tab-content table thead tr,
 .lb-table table thead tr,
 .text-formatted table thead tr,
@@ -27,6 +29,7 @@
   border-bottom: 5px solid var(--ylb-color-grey-2, #cccccc);
 }
 
+.field-branch-hours table thead tr th,
 .tab-content table thead tr th,
 .lb-table table thead tr th,
 .text-formatted table thead tr th,
@@ -40,6 +43,7 @@
 }
 
 @media (min-width: 992px) {
+  .field-branch-hours table thead tr th,
   .tab-content table thead tr th,
   .lb-table table thead tr th,
   .text-formatted table thead tr th,
@@ -50,6 +54,7 @@
   }
 }
 
+.field-branch-hours table tbody tr,
 .tab-content table tbody tr,
 .lb-table table tbody tr,
 .text-formatted table tbody tr,
@@ -58,6 +63,7 @@
   border-bottom: 2px solid var(--ylb-color-light-grey-3, #e0e0e0);
 }
 
+.field-branch-hours table tbody tr td,
 .tab-content table tbody tr td,
 .lb-table table tbody tr td,
 .text-formatted table tbody tr td,

--- a/assets/css/tables.css
+++ b/assets/css/tables.css
@@ -7,7 +7,6 @@
  */
 
 /* Apply to all formatted text fields that may contain CKEditor tables */
-.field-item table,
 .tab-content table,
 .lb-table table,
 .text-formatted table,
@@ -19,7 +18,6 @@
   margin: 1em 0;
 }
 
-.field-item table thead tr,
 .tab-content table thead tr,
 .lb-table table thead tr,
 .text-formatted table thead tr,
@@ -29,7 +27,6 @@
   border-bottom: 5px solid var(--ylb-color-grey-2, #cccccc);
 }
 
-.field-item table thead tr th,
 .tab-content table thead tr th,
 .lb-table table thead tr th,
 .text-formatted table thead tr th,
@@ -43,7 +40,6 @@
 }
 
 @media (min-width: 992px) {
-  .field-item table thead tr th,
   .tab-content table thead tr th,
   .lb-table table thead tr th,
   .text-formatted table thead tr th,
@@ -54,7 +50,6 @@
   }
 }
 
-.field-item table tbody tr,
 .tab-content table tbody tr,
 .lb-table table tbody tr,
 .text-formatted table tbody tr,
@@ -63,7 +58,6 @@
   border-bottom: 2px solid var(--ylb-color-light-grey-3, #e0e0e0);
 }
 
-.field-item table tbody tr td,
 .tab-content table tbody tr td,
 .lb-table table tbody tr td,
 .text-formatted table tbody tr td,


### PR DESCRIPTION
## Summary

- Removed `.field-item table` selector from all style rules in `tables.css`

## Problem

After deploying ITCR-1107 global table styles to sites using y_lb, some component styles were broken. The root cause is that `.field-item` is a generic Drupal wrapper class applied to **all** field output — not just CKEditor text fields. This caused the table styles to unintentionally override styling on tables inside components like views, entity reference listings, and other non-CKEditor contexts.

## Fix

Removed `.field-item table` from all 6 selector blocks in `tables.css`. The remaining selectors are scoped to specific contexts where CKEditor tables actually appear:

- `.tab-content table` — tab components
- `.lb-table table` — Layout Builder table blocks
- `.text-formatted table` — formatted text fields
- `.field--type-text-with-summary table` — text with summary fields
- `.field--type-text-long table` — long text fields

## Test plan

- [ ] Verify CKEditor tables still render correctly in text fields
- [ ] Verify component tables (views, entity references) are no longer affected by global table styles
- [ ] Check sites that reported broken styles after ITCR-1107 deployment