### PR TITLE
fix: resolve PHP 8.4 implicit nullable and Symfony Request::get() deprecations

### DIFF
--- a/src/EventSubscriber/PrepareLayout.php
+++ b/src/EventSubscriber/PrepareLayout.php
@@ -88,7 +88,7 @@ class PrepareLayout implements EventSubscriberInterface {
     if ($this->layoutTempstoreRepository->has($section_storage)) {
 
       // Add warning message after loaded page or triggered submit button.
-      $triggeringElementName = $request->get('_triggering_element_name');
+      $triggeringElementName = $request->request->get('_triggering_element_name');
       if (empty($triggeringElementName) || $triggeringElementName === 'op') {
         $this->messenger->addWarning($this->t('You have unsaved changes.'));
       }

--- a/src/Form/YLBEntityViewDisplay.php
+++ b/src/Form/YLBEntityViewDisplay.php
@@ -14,7 +14,7 @@ class YLBEntityViewDisplay extends DefaultsEntityForm {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, SectionStorageInterface $section_storage = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?SectionStorageInterface $section_storage = NULL) {
     $settings = $this->entity->getThirdPartySettings('y_lb');
     $form['ws_settings_container'] = [
       '#type' => 'details',

--- a/src/Form/YLBOverridesEntityForm.php
+++ b/src/Form/YLBOverridesEntityForm.php
@@ -14,7 +14,7 @@ class YLBOverridesEntityForm extends OverridesEntityForm {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, SectionStorageInterface $section_storage = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?SectionStorageInterface $section_storage = NULL) {
     $node = $this->entity;
     $settings = $node->styles->value ? unserialize($node->styles->value) : [];
 

--- a/src/Plugin/Block/SiteLogoBlock.php
+++ b/src/Plugin/Block/SiteLogoBlock.php
@@ -79,7 +79,7 @@ class SiteLogoBlock extends BlockBase implements ContainerFactoryPluginInterface
    * @param \Drupal\Core\Extension\ModuleExtensionList $module_list
    *   The module list service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $currentRouteMatch, ConfigFactoryInterface $config_factory, FileUrlGeneratorInterface $file_url_generator = NULL, ModuleExtensionList $module_list = NULL) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $currentRouteMatch, ConfigFactoryInterface $config_factory, ?FileUrlGeneratorInterface $file_url_generator = NULL, ?ModuleExtensionList $module_list = NULL) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->currentRouteMatch = $currentRouteMatch;
     $this->node = $currentRouteMatch->getParameter('node');

--- a/src/Plugin/migrate/process/YLBSection.php
+++ b/src/Plugin/migrate/process/YLBSection.php
@@ -37,7 +37,7 @@ class YLBSection extends ProcessPluginBase implements ContainerFactoryPluginInte
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) {
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?MigrationInterface $migration = NULL) {
     $instance = new static(
       $configuration,
       $plugin_id,


### PR DESCRIPTION
## Summary

Fixes deprecated function warnings generating ~21K messages/day across YMCA sites.

- Add `?` prefix to nullable typed parameters in:
  - `SiteLogoBlock::__construct()` — `?FileUrlGeneratorInterface`, `?ModuleExtensionList`
  - `YLBOverridesEntityForm::buildForm()` — `?SectionStorageInterface` (parent already fixed)
  - `YLBEntityViewDisplay::buildForm()` — `?SectionStorageInterface` (parent already fixed)
  - `YLBSection::create()` — `?MigrationInterface` (core already fixed)
- Replace deprecated `Request::get()` with `Request::request->get()` in `PrepareLayout::onKernelRequest()` (Symfony 5.4 deprecation)

## Test plan

- [ ] Enable `dblog`, clear caches (`drush cr`), browse homepage
- [ ] Run `drush ws --type=php --count=50` — confirm no `SiteLogoBlock` implicit nullable deprecation messages
- [ ] Open Layout Builder on a node — confirm no PHP warnings
- [ ] Verify Layout Builder pending changes warning still appears on reload

Refs: ITCR-1129